### PR TITLE
Fix config.sample.php SLACK_API_TOKEN

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -6,4 +6,4 @@ define('TEAM_SUB_DOMAIN','FILL ME');
 
 // API TOKEN.
 // ref: https://api.slack.com/web
-define('API_TOKEN','xoxp-xxxxxx....FILL_ME');
+define('SLACK_API_TOKEN','xoxp-xxxxxx....FILL_ME');


### PR DESCRIPTION
The env must have been update to `SLACK_API_TOKEN` but the config example still uses `API_TOKEN`. This fixes that.